### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,6 +1,8 @@
 ofxstatement (0.6.4-3) UNRELEASED; urgency=medium
 
   * Use secure copyright file specification URI.
+  * Set upstream metadata fields: Bug-Database, Bug-Submit, Repository,
+    Repository-Browse.
 
  -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 11:31:38 +0000
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+ofxstatement (0.6.4-3) UNRELEASED; urgency=medium
+
+  * Use secure copyright file specification URI.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 05 May 2020 11:31:38 +0000
+
 ofxstatement (0.6.4-2) unstable; urgency=medium
 
   * d/control: wrap-and-sort.

--- a/debian/copyright
+++ b/debian/copyright
@@ -1,4 +1,4 @@
-Format: http://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
+Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: ofxstatement
 Source: https://github.com/kedder/ofxstatement
 

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,0 +1,4 @@
+Bug-Database: https://github.com/kedder/ofxstatement/issues
+Bug-Submit: https://github.com/kedder/ofxstatement/issues/new
+Repository: https://github.com/kedder/ofxstatement.git
+Repository-Browse: https://github.com/kedder/ofxstatement


### PR DESCRIPTION
Fix some issues reported by lintian
* Use secure copyright file specification URI. ([insecure-copyright-format-uri](https://lintian.debian.org/tags/insecure-copyright-format-uri.html))
* Set upstream metadata fields: Bug-Database, Bug-Submit, Repository, Repository-Browse. ([upstream-metadata-file-is-missing](https://lintian.debian.org/tags/upstream-metadata-file-is-missing.html), [upstream-metadata-missing-bug-tracking](https://lintian.debian.org/tags/upstream-metadata-missing-bug-tracking.html), [upstream-metadata-missing-repository](https://lintian.debian.org/tags/upstream-metadata-missing-repository.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/ofxstatement/382d908e-1899-45ff-8d3d-5f09f0c224c3.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/382d908e-1899-45ff-8d3d-5f09f0c224c3/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/382d908e-1899-45ff-8d3d-5f09f0c224c3/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/382d908e-1899-45ff-8d3d-5f09f0c224c3/diffoscope)).
